### PR TITLE
Use `getEnforcing` instead of unsafe `get` cast

### DIFF
--- a/src/NativeTurboStarter.ts
+++ b/src/NativeTurboStarter.ts
@@ -31,5 +31,4 @@ export interface Spec extends TurboModule {
   turboMultiply(num1: number, num2: number): number;
 }
 
-// We know the module is going to be load so we export with the "!" so it doesn't add undefined to every function return value
-export default TurboModuleRegistry.get<Spec>('TurboStarter')!;
+export default TurboModuleRegistry.getEnforcing<Spec>('TurboStarter');


### PR DESCRIPTION
`get` + a force-cast is not safe. Instead, use `getEnforcing`, the type-safe method that will throw an error if it's not found.